### PR TITLE
Fix a pair of function names

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
@@ -294,7 +294,7 @@ public:
 	bool         IsAnimationDrivenMotionEnabled() const { return m_bAnimationDrivenMotion; }
 
 	virtual void SetCharacterFile(const char* szPath);
-	const char*  SetCharacterFile() const                  { return m_characterFile.value.c_str(); }
+	const char*  GetCharacterFile() const                  { return m_characterFile.value.c_str(); }
 	virtual void SetMannequinAnimationDatabaseFile(const char* szPath);
 	const char*  GetMannequinAnimationDatabaseFile() const { return m_databasePath.value.c_str(); }
 

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AnimatedMeshComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AnimatedMeshComponent.h
@@ -67,7 +67,7 @@ namespace Cry
 			virtual void SetLayer(int layer) { m_animationParams.m_nLayerID = layer; }
 
 			virtual void SetCharacterFile(const char* szPath);
-			const char* SetCharacterFile() const { return m_filePath.value.c_str(); }
+			const char* GetCharacterFile() const { return m_filePath.value.c_str(); }
 
 			virtual void SetDefaultAnimationName(const char* szPath);
 			const char* GetDefaultAnimationName() const { return m_defaultAnimation.value.c_str(); }


### PR DESCRIPTION
Two functions in CAdvancedAnimationComponent and CAnimatedMeshComponent have names which don't match their function; likely a copy and paste error.

They need to be renamed to GetCharacterFile.